### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Documentation
 on:
   push:
     branches: [main]
+    paths:
+      - Sources/**
+      - "**/*.md"
+      - Package.swift
+      - .github/workflows/docs.yml
 
 concurrency:
   group: "pages"
@@ -16,8 +21,9 @@ permissions:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure Git for private repos
         run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
@@ -44,6 +50,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,13 +2,32 @@ name: macOS
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,33 @@ name: ubuntu
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Standardizes the GitHub Actions workflows for swift-mint (PUBLIC, swift-spm) to match the CorvidLabs/merlin CI standard.

## Changes
- **macOS.yml** & **ubuntu.yml** (push/PR CI):
  - Added `paths:` filters scoped to `Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, and the workflow file itself (docs/LICENSE-only changes no longer trigger full build+test).
  - Added a `pull_request` trigger (CI previously ran on push only).
  - Scoped push trigger to `branches: [main]` (was `["**"]`).
  - Added a `concurrency:` group keyed on `github.ref` with `cancel-in-progress: true`.
  - Bumped `actions/checkout@v4` to `@v5` and added `timeout-minutes` per job.
- **docs.yml** (pages/deploy):
  - Added a site-source-scoped `paths:` filter (`Sources/**`, `**/*.md`, `Package.swift`, the workflow file).
  - Bumped `actions/checkout@v5` and added `timeout-minutes` per job; preserved existing DocC build/deploy logic and `pages` concurrency.

## Runners
- Repo is PUBLIC, so all runners remain GitHub-hosted (`macos-latest` / `ubuntu-latest`) — already compliant, no self-hosted routing.

Validated with `python3 -c "import yaml; yaml.safe_load(...)"` and `actionlint` (exit 0).

Mirrors the CorvidLabs/merlin CI standard.