### PR TITLE
Fix: bump SPM install version floor to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add Mint to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/CorvidLabs/swift-mint.git", from: "0.0.1")
+    .package(url: "https://github.com/CorvidLabs/swift-mint.git", from: "0.1.0")
 ]
 ```
 


### PR DESCRIPTION
Problem: The SPM installation snippet pins `from: "0.0.1"`, but the latest published release is 0.1.0. The example version predates the actual first release tag.

Fix: Update the install snippet to `.package(url: "https://github.com/CorvidLabs/swift-mint.git", from: "0.1.0")` to match the latest release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)